### PR TITLE
Page through more than 200 activities

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,8 +97,6 @@ Notes:
 - Different activity types are rendered using different colors. Colors are
   defined by `lineStyle` in `user.settings.json`. The default set of colors is
   defined by `defaultLineStyles` in `lib/kml.ts`.
-- There is a Strava limit of 200 activities per call, so for date ranges that
-  include more than 200 activities, only the first 200 activities are returned.
 
 ### Example Command Line Use
 
@@ -188,7 +186,6 @@ been modified.
 
 ## ToDo
 
-- Handle paginated data, in other words, requests that exceed 200 activities.
 - I started working on a PDF report generator, however I have barely begun this
   effort and will probably not ever complete it. It is at `bin/pdfgen.js`.
 - Get `--segment` working again

--- a/src/main.ts
+++ b/src/main.ts
@@ -229,13 +229,15 @@ export class Main {
       });
   }
 
-  getActivitiesForDateRange(dateRange: DateRange): Promise<Activity[]> {
+  getActivitiesForDateRange(dateRange: DateRange, page: number = 1): Promise<Activity[]> {
+    let page_size: number = 200;
     let params: StravaActivityOpts = {
       athleteId: this.options.athleteId,
       query: {
-        per_page: 200,
+        per_page: page_size,
         after: dateRange.after,
-        before: dateRange.before
+        before: dateRange.before,
+	page: page
       }
     };
     return this.strava.getActivities(params).then(resp => {
@@ -247,7 +249,13 @@ export class Main {
           results.push(activity);
         }
       });
-      return Promise.resolve(results);
+      if(activities.length < page_size) {
+          return Promise.resolve(results);
+      } else {
+          return this.getActivitiesForDateRange(dateRange, page + 1).then(tail_results => {
+              return Promise.resolve(results.concat(tail_results));
+          });
+      }
     });
   }
 


### PR DESCRIPTION
I just hit the 200 activities limit, so here's my attempt to run through multiple pages.

If the current page has the maximum number of activities, that is taken as a signal to recurse and request everything from the next page onwards.